### PR TITLE
Python3 compatibility update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: python
 python:
   - 2.7
+  - 3.4
+  - 3.5
 install:
   - pip install coveralls
   - pip install nose
+  - pip install six
 script:
   coverage run --source=taxon_names_resolver setup.py test
 after_success:

--- a/TaxonNamesResolver.py
+++ b/TaxonNamesResolver.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 #! /usr/bin/env python
 # D.J. Bennett
 # 16/05/2014
@@ -60,17 +62,17 @@ def logEndTime():
 if __name__ == '__main__':
     args = parseArgs()
     if args.details:
-        print '\nThis is TaxonNamesResolver, version: [{0}]'.format(version)
-        print details
+        print('\nThis is TaxonNamesResolver, version: [{0}]'.format(version))
+        print(details)
         sys.exit()
     if not args.names:
-        print 'No names file provided!'
-        print 'Type `TaxonNamesResolver.py -h` for help.'
+        print('No names file provided!')
+        print('Type `TaxonNamesResolver.py -h` for help.')
         sys.exit()
     if not os.path.isfile(args.names):
-        print '[{0}] could not be found!'.format(args.names)
+        print('[{0}] could not be found!'.format(args.names))
         sys.exit()
-    print '\n' + description + '\n'
+    print('\n' + description + '\n')
     if args.datasource:
         datasource = args.datasource
     else:
@@ -93,4 +95,4 @@ if __name__ == '__main__':
     resolver.write()
     logEndTime()
     if not args.verbose:
-        print '\nComplete\n'
+        print('\nComplete\n')

--- a/example.py
+++ b/example.py
@@ -5,6 +5,8 @@
 '''
 Example script for using taxon_names_resolver
 '''
+from __future__ import absolute_import
+from __future__ import print_function
 
 # SETUP LOGGING (OPTIONAL)
 import logging
@@ -68,13 +70,13 @@ taxdict['Homo sapiens']['ident']
 taxdict['Arabidopsis thaliana']['cident']  # A. thaliana is the only plant
 # the 'taxref', a holder of 'ident' and taxonomic posistion. Requires printing
 #  e.g. C. tytonis could only resolved to the genus level (22/01/2015)
-print taxdict['Chlorotalpa tytonis']['taxref']
+print(taxdict['Chlorotalpa tytonis']['taxref'])
 # check the taxonomy
-print taxdict.taxonomy
+print(taxdict.taxonomy)
 # check the hierarchy, a dictionary of taxrefs ranked and grouped in the form:
 #  {'rank':[([taxref1, taxref2, ....],'lineage1'),
 #           ([taxref3, taxref4, ....],'lineage2'), ....]}
-print taxdict.hierarchy
+print(taxdict.hierarchy)
 # we've also added an extra data slot
 taxdict['Homo sapiens']['extra']
 

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,13 @@
 """
 TaxonNamesResolver setup
 """
+from __future__ import absolute_import
 
 # PACKAGES
 import os
 import taxon_names_resolver
 from setuptools import setup, find_packages
+from six.moves import zip
 
 # FIND
 PACKAGES = find_packages()
@@ -30,7 +32,7 @@ setup(
     url="https://github.com/DomBennett/TaxonNamesResolver",
     download_url=url,
     packages=PACKAGES,
-    package_dir=dict(zip(PACKAGES, PACKAGE_DIRS)),
+    package_dir=dict(list(zip(PACKAGES, PACKAGE_DIRS))),
     test_suite='tests',
     scripts=['TaxonNamesResolver.py'],
     long_description=taxon_names_resolver.__doc__,

--- a/taxon_names_resolver/__init__.py
+++ b/taxon_names_resolver/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 #! /usr/bin/env python
 # D.J. Bennett
 # 01/06/2014

--- a/taxon_names_resolver/gnr_tools.py
+++ b/taxon_names_resolver/gnr_tools.py
@@ -4,13 +4,14 @@
 """
 Tools for interacting with the GNR.
 """
+from __future__ import absolute_import
 
 import time
 import contextlib
 import json
-import urllib
-import urllib2
 import os
+import six
+from six.moves import urllib
 
 
 # FUNCTIONS
@@ -20,7 +21,7 @@ def safeReadJSON(url, logger, max_check=6, waittime=30):
     # try, try and try again ....
     while counter < max_check:
         try:
-            with contextlib.closing(urllib2.urlopen(url)) as f:
+            with contextlib.closing(urllib.request.urlopen(url)) as f:
                 res = json.loads(f.read())
             return res
         except Exception as errmsg:
@@ -91,7 +92,7 @@ Return JSON object."""
         # TODO(07/06/2013): record DSs used
         alt_terms = []
         for record in jobj:
-            if 'results' not in record.keys():
+            if 'results' not in list(record.keys()):
                 pass
             else:
                 term = record['supplied_name_string']
@@ -134,7 +135,7 @@ Return JSON object."""
 
     def _query(self, terms, data_source_ids):
         ds_ids = [str(id) for id in data_source_ids]
-        terms = [urllib.quote(unicode(t).encode('utf8')) for t in terms]
+        terms = [urllib.parse.quote(six.text_type(t).encode('utf8')) for t in terms]
         url = ('http://resolver.globalnames.org/name_resolvers.json?' +
                'data_source_ids=' + '|'.join(ds_ids) + '&' +
                'resolve_once=false&' + 'names=' + '|'.join(terms))
@@ -174,7 +175,7 @@ class GnrStore(dict):
             for record in jobj:
                 term = record['supplied_name_string']
                 try:
-                    if 'results' in record.keys():
+                    if 'results' in list(record.keys()):
                         results = self._filter(record['results'])
                         self[term].extend(results)
                 except KeyError:
@@ -184,7 +185,7 @@ class GnrStore(dict):
         for record in jobj:
             term = record['supplied_name_string']
             try:
-                if 'results' in record.keys():
+                if 'results' in list(record.keys()):
                     results = self._filter(record['results'])
                     self[term] = results
                 else:

--- a/taxon_names_resolver/gnr_tools.py
+++ b/taxon_names_resolver/gnr_tools.py
@@ -22,7 +22,7 @@ def safeReadJSON(url, logger, max_check=6, waittime=30):
     while counter < max_check:
         try:
             with contextlib.closing(urllib.request.urlopen(url)) as f:
-                res = json.loads(f.read())
+                res = json.loads(f.read().decode('utf8'))
             return res
         except Exception as errmsg:
             logger.info('----- GNR error [{0}] : retrying ----'.format(errmsg))

--- a/taxon_names_resolver/manip_tools.py
+++ b/taxon_names_resolver/manip_tools.py
@@ -135,7 +135,7 @@ same length as idents')
         if level >= len(self.taxonomy):
             raise IndexError('Level greater than size of taxonomy')
         res = []
-        for ident in list(self.keys()):
+        for ident in sorted(list(self.keys())):
             res.append((self[ident]['taxref'], self[ident]['lineage'][level]))
         return res
 

--- a/taxon_names_resolver/manip_tools.py
+++ b/taxon_names_resolver/manip_tools.py
@@ -4,9 +4,11 @@
 """
 misc tools
 """
+from __future__ import absolute_import
 
 # PACKAGES
 import re
+from six.moves import range
 
 # GLOBALS
 # nodes on a taxonomic tree
@@ -120,7 +122,7 @@ class TaxDict(dict):
     def _additional(self, idents, kwargs):
         '''Add additional data slots from **kwargs'''
         if kwargs:
-            for name, value in kwargs.items():
+            for name, value in list(kwargs.items()):
                 if not isinstance(value, list):
                     raise ValueError('Additional arguments must be lists of \
 same length as idents')
@@ -133,7 +135,7 @@ same length as idents')
         if level >= len(self.taxonomy):
             raise IndexError('Level greater than size of taxonomy')
         res = []
-        for ident in self.keys():
+        for ident in list(self.keys()):
             res.append((self[ident]['taxref'], self[ident]['lineage'][level]))
         return res
 

--- a/taxon_names_resolver/resolver.py
+++ b/taxon_names_resolver/resolver.py
@@ -6,6 +6,7 @@
 """
 Resolver class for parsing GNR records.
 """
+from __future__ import absolute_import
 
 import json
 import os
@@ -13,9 +14,10 @@ import csv
 import re
 import copy
 import logging
-from gnr_tools import GnrStore
-from gnr_tools import GnrResolver
-import urllib
+from .gnr_tools import GnrStore
+from .gnr_tools import GnrResolver
+import six
+from six.moves import zip, urllib
 
 
 # CLASSES
@@ -71,7 +73,7 @@ See https://github.com/DomBennett/TaxonNamesResolver for details."""
         """Check terms do not contain unknown characters"""
         for t in terms:
             try:
-                _ = urllib.quote(unicode(t).encode('utf8'))
+                _ = urllib.parse.quote(six.text_type(t).encode('utf8'))
             except:
                 self.logger.error('Unknown character in [{0}]!'.format(t))
                 self.logger.error('.... remove character and try again.')
@@ -141,7 +143,7 @@ See https://github.com/DomBennett/TaxonNamesResolver for details."""
         #  greater or less than nrecords
         GnrStore = self._store
         assessed = []
-        lens = [len(GnrStore[key]) for key in GnrStore.keys()]
+        lens = [len(GnrStore[key]) for key in list(GnrStore.keys())]
         if greater:
             len_bools = [each > nrecords for each in lens]
         else:
@@ -216,10 +218,10 @@ true) and/or are the first item returned."""
         txt_file = os.path.join(self.outdir, 'unresolved.txt')
         headers = self.key_terms
         unresolved = []
-        with open(csv_file, 'wb') as file:
+        with open(csv_file, 'w') as file:
             writer = csv.writer(file)
             writer.writerow(headers)
-            for key in self._store.keys():
+            for key in list(self._store.keys()):
                 results = self._store[key]
                 if len(results) == 0:
                     unresolved.append(key)
@@ -249,7 +251,7 @@ Possible terms (02/12/2013): 'query_name', 'classification_path',
 valid terms.')
         store = self._store
         retrieved = []
-        for key in store.keys():
+        for key in list(store.keys()):
             # take copy, so changes made to the returned list do not affect
             #  store
             record = copy.deepcopy(store[key])

--- a/taxon_names_resolver/resolver.py
+++ b/taxon_names_resolver/resolver.py
@@ -230,8 +230,16 @@ true) and/or are the first item returned."""
                     for key_term in headers[1:]:
                         element = results[0][key_term]
                         # GNR returns UTF-8, csv requires ascii
-                        if 'encode' in dir(element):
-                            element = element.encode('ascii')
+                        #
+                        # *** Note ***
+                        # According to all docs for csv versions >= 2.6, csv
+                        # can handle either UTF-8 or ascii, just not Unicode.
+                        # In py3, the following two lines result in csv printing
+                        # the element with a bitstring. If GNR is actually
+                        # returning UTF-8, it seems easiest to just drop these
+
+                        # if 'encode' in dir(element):
+                        #     element = element.encode('ascii')
                         row.append(element)
                     writer.writerow(row)
         if len(unresolved) > 0:

--- a/tests/test_gnr_tools.py
+++ b/tests/test_gnr_tools.py
@@ -2,6 +2,7 @@
 """
 Tests for GNR tools
 """
+from __future__ import absolute_import
 
 import unittest
 import json

--- a/tests/test_manip_tools.py
+++ b/tests/test_manip_tools.py
@@ -2,6 +2,7 @@
 """
 Tests for misc tools
 """
+from __future__ import absolute_import
 
 import unittest
 from taxon_names_resolver import manip_tools as mt
@@ -140,7 +141,7 @@ class ManipToolsTestSuite(unittest.TestCase):
         rung = taxdict._group(taxslice)
         self.assertEqual(len(rung), 2)
         # all the levels of the taxonomy should be in the hierarchy
-        self.assertTrue(all([e in taxonomy for e in taxdict.hierarchy.keys()]))
+        self.assertTrue(all([e in taxonomy for e in list(taxdict.hierarchy.keys())]))
         # Bacillus subtilus is the ONLY bacteria
         self.assertEqual(taxdict['Bacillus subtilus']['cident'], 'Bacteria')
 

--- a/tests/test_manip_tools.py
+++ b/tests/test_manip_tools.py
@@ -155,13 +155,14 @@ class ManipToolsTestSuite(unittest.TestCase):
     def test_taxtree(self):
         taxdict = mt.TaxDict(idents=idents, ranks=ranks, lineages=lineages)
         treestring = mt.taxTree(taxdict)
+        print(treestring)
         # not the best test as newick string order can be arbritrary
-        self.assertEqual(treestring, '(((((((Homo_sapiens:4.0,Gorilla_gorilla:\
-4.0)Homininae_subfamily:1.0,Pongo_pongo:3.0)Hominidae_family:2.0,Macca_mulatta:\
-7.0)Catarrhini_parvorder:4.0,Mus_musculus:11.0)Euarchontoglires_superorder:4.0,\
-(Ailuropoda_melanoleuca:9.0,Ailurus_fulgens:9.0)Caniformia_suborder:6.0,\
-Chlorotalpa_tytonis:13.0)Mammalia_class:5.0,Arabidopsis_thaliana:20.0)\
-Eukaryota_superkingdom:1.0,Bacillus_subtilus:21.0)life;')
+        self.assertEqual(treestring, '((((Ailuropoda_melanoleuca:9.0,\
+Ailurus_fulgens:9.0)Caniformia_suborder:6.0,Chlorotalpa_tytonis:13.0,\
+((((Gorilla_gorilla:4.0,Homo_sapiens:4.0)Homininae_subfamily:1.0,\
+Pongo_pongo:3.0)Hominidae_family:2.0,Macca_mulatta:7.0)Catarrhini_parvorder:4.0,\
+Mus_musculus:11.0)Euarchontoglires_superorder:4.0)Mammalia_class:5.0,\
+Arabidopsis_thaliana:20.0)Eukaryota_superkingdom:1.0,Bacillus_subtilus:21.0)life;')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_manip_tools.py
+++ b/tests/test_manip_tools.py
@@ -155,8 +155,7 @@ class ManipToolsTestSuite(unittest.TestCase):
     def test_taxtree(self):
         taxdict = mt.TaxDict(idents=idents, ranks=ranks, lineages=lineages)
         treestring = mt.taxTree(taxdict)
-        print(treestring)
-        # not the best test as newick string order can be arbritrary
+        
         self.assertEqual(treestring, '((((Ailuropoda_melanoleuca:9.0,\
 Ailurus_fulgens:9.0)Caniformia_suborder:6.0,Chlorotalpa_tytonis:13.0,\
 ((((Gorilla_gorilla:4.0,Homo_sapiens:4.0)Homininae_subfamily:1.0,\

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -2,6 +2,7 @@
 """
 Tests for Resolver
 """
+from __future__ import absolute_import
 
 import unittest
 import json
@@ -132,7 +133,7 @@ speciesA,GenusA speciesA,|51|41|31|21|11|1,3|0|0,1,1,test_number1'
         # test the searches
         # the results should equal 10
         self.resolver1.main()
-        res = self.resolver1._store.keys()
+        res = list(self.resolver1._store.keys())
         self.assertEqual(len(res), 10)
 
     def test_resolver_private_sieve(self):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -9,6 +9,7 @@ import json
 import os
 import shutil
 import taxon_names_resolver as tnr
+import six
 
 # TEST DATA
 # results from the first search
@@ -107,20 +108,54 @@ class ResolverTestSuite(unittest.TestCase):
 
     def test_resolver_write(self):
         # write out csv and read in and check
-        exp = 'GenusA speciesA,|kingdomA|phylumA|orderA|familyA|genusA|speciesA,\
-test_source,1,1.0,|kingdom|phylum|order|family|genus|species,GenusA \
-speciesA,GenusA speciesA,|51|41|31|21|11|1,3|0|0,1,1,test_number1'
+        exp_header = 'query_name,classification_path,data_source_title,\
+match_type,score,classification_path_ranks,name_string,\
+canonical_form,classification_path_ids,prescore,\
+data_source_id,taxon_id,gni_uuid'
+        exp_results = ['GenusA speciesA,|kingdomA|phylumA|orderA|familyA|genusA|speciesA,\
+test_source,1,1.0,|kingdom|phylum|order|family|genus|species,\
+GenusA speciesA,GenusA speciesA,|51|41|31|21|11|1,3|0|0,1,1,test_number1',
+'GenusA speciesB,|kingdomA|phylumA|orderA|familyA|genusA|speciesB,\
+test_source,1,1.0,|kingdom|phylum|order|family|genus|species,\
+GenusA speciesB,GenusA speciesB,|51|41|31|21|11|2,3|0|0,1,2,test_number2',
+'GenusA speciesC,|kingdomA|phylumA|orderA|familyA|genusA|speciesC,\
+test_source,1,1.0,|kingdom|phylum|order|family|genus|species,\
+GenusA speciesC,GenusA speciesC,|51|41|31|21|11|3,3|0|0,1,3,test_number3',
+'GenusC speciesF,|kingdomA|phylumA|orderA|familyB|genusC|speciesF,\
+test_source,1,1.0,|kingdom|phylum|order|family|genus|species,\
+GenusC speciesF,GenusC speciesF,|51|41|31|22|13|6,3|0|0,1,6,test_number6',
+'GenusD speciesG,|kingdomA|phylumA|orderB|familyC|genusD|speciesG,\
+test_source,1,1.0,|kingdom|phylum|order|family|genus|species,\
+GenusD speciesG,GenusD speciesG,|51|41|32|23|14|7,3|0|0,1,7,test_number7',
+'GenusB speciesE,|kingdomA|phylumA|orderA|familyA|genusB|speciesE,\
+test_source,1,1.0,|kingdom|phylum|order|family|genus|species,\
+GenusB speciesE,GenusB speciesE,|51|41|31|21|12|5,3|0|0,1,5,test_number5',
+'GenusB speciesD,|kingdomA|phylumA|orderA|familyA|genusB|speciesD,\
+test_source,1,1.0,|kingdom|phylum|order|family|genus|species,\
+GenusB speciesD,GenusB speciesD,|51|41|31|21|12|4,3|0|0,1,4,test_number4',
+'GenusF speciesI,|kingdomA|phylumC|orderD|familyE|genusF|speciesI,\
+test_source,1,1.0,|kingdom|phylum|order|family|genus|species,\
+GenusF speciesI,GenusF speciesI,|51|43|34|25|16|9,3|0|0,1,9,test_number9',
+'GenusE speciesH,|kingdomA|phylumB|orderC|familyD|genusE|speciesH,\
+test_source,1,1.0,|kingdom|phylum|order|family|genus|species,\
+GenusE speciesH,GenusE speciesH,|51|42|33|24|15|8,3|0|0,1,8,test_number8']
+        
         self.resolver2.write()
         with open(os.path.join('resolved_names', 'unresolved.txt'), 'r')\
-                as file:
-            res = file.readline().strip('\n')
+                as f:
+            res = f.readline().strip('\n')
         self.assertEqual(res, 'GenusG speciesJ')
+
         with open(os.path.join('resolved_names', 'search_results.csv'), 'r')\
-                as file:
-            _skip = file.readline()
-            res = file.readline().strip()
-        del _skip
-        self.assertEqual(res, exp)
+                as f:
+            obs_lines = [line.rstrip() for line in f]
+
+        print(obs_lines[1:])
+        print('\n\nobserved\n\n')
+        print(exp_results)
+        self.assertEqual(exp_header, obs_lines[0])
+        six.assertCountEqual(self, exp_results, obs_lines[1:])
+
         shutil.rmtree('resolved_names')
 
     def test_resolver_retrieve(self):


### PR DESCRIPTION
Nice library! I'd like to use this with some code I'm writing in Py3, so I figured I could contribute a bit to issue #1.

The port wasn't too tricky, but there are a few things that probably need some review (see especially comment on line 234 of resolver.py). To maintain compatibility across Python versions I used six, so this does require an additional library. Many of the remaining changes centered around string encoding in Py3 and the fact that ordering of dict keys is less predictable in Python 3.
